### PR TITLE
fix for docker build error:fatal error: openssl/opensslv.h: No such file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ RUN sed -i 's/http_access deny all/http_access allow all/g' /etc/squid/squid.con
 #RUN which pip3|xargs -i ln -s {} /usr/bin/pip
 COPY . /haipproxy
 WORKDIR /haipproxy
-RUN pip3 install --upgrade pip && pip3 install -i https://pypi.douban.com/simple/ -r requirements.txt 
+RUN apt install python-pip python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev libjpeg8-dev zlib1g-dev -yq
+RUN pip3 install --upgrade pip && pip3 install -i https://pypi.douban.com/simple/ -r requirements.txt
 #CMD ['python3', 'crawler_booter.py', '--usage', 'crawler', 'common']


### PR DESCRIPTION
我在下面的环境中build docker image会报错:

`fatal error: openssl/opensslv.h: No such file or directory`

 ENV:
```
Ubuntu16.04 LTS
Docker version 18.03.0-ce, build 0520e24
```

pull的最近的ubuntu image为:

`ubuntu                   16.04               5e8b97a2a082        4 weeks ago         114MB`

需要加一下依赖包才能通过，参考:
https://askubuntu.com/questions/797351/fatal-error-openssl-opensslv-h-no-such-file-or-directory-compiling-mitmproxy
