### PR TITLE
fix(sec): upgrade scrapy-splash to 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ schedule==0.5.0
 Twisted==17.9.0
 Flask==1.0.2
 Scrapy==1.5.0
-scrapy-splash==0.7.2
+scrapy-splash==0.8.0
 prometheus-client==0.2.0
 click==6.7


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in scrapy-splash 0.7.2
- [CVE-2021-41124](https://www.oscs1024.com/hd/CVE-2021-41124)


### What did I do？
Upgrade scrapy-splash from 0.7.2 to 0.8.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS